### PR TITLE
Make type creation idempotent

### DIFF
--- a/sql/base_domain.sql
+++ b/sql/base_domain.sql
@@ -5,8 +5,12 @@
 -- OVERLOADS: TSQuery
 -- Enforces a query that is BOTH UNACCENTed and contains no infix characters; 
 -- \W+ will capture 
-CREATE DOMAIN TSPQuery AS TSQuery 
-NOT NULL CHECK (value::TEXT !~ '[\w+][\W+][\w]');
+DO $$ BEGIN
+    CREATE DOMAIN TSPQuery AS TSQuery
+    NOT NULL CHECK (value::TEXT !~ '[\w+][\W+][\w]');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
 
 -- Note:
 -- 1) in TO_TSPVECTOR er inject a dummy, marker node into the max lexeme 
@@ -16,5 +20,9 @@ NOT NULL CHECK (value::TEXT !~ '[\w+][\W+][\w]');
 
 -- A TSPVector 'proves' it has been pre-processed by inserting the
 -- ProcessedUnaccentedTSPIndexableText at the maximum position.
-CREATE DOMAIN TSPVector AS TSVector 
-NOT NULL CHECK (value @@ 'ProcessedUnaccentedTSPIndexableText'::TSQUERY);
+DO $$ BEGIN
+    CREATE DOMAIN TSPVector AS TSVector
+    NOT NULL CHECK (value @@ 'ProcessedUnaccentedTSPIndexableText'::TSQUERY);
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;


### PR DESCRIPTION
If the type already exists, catch the exception and move on. If some other kind of exception happens, it will also get ignored, but... hopefully that's uncommon.

This isn't really necessary if the code is being properly loaded as an extension, because you can drop the entire extension and then load up the new version. But @thevermeer and I were loading the code directly on a remote DB where we couldn't install extensions, and running into problems with updating.

I _think_ this is generally pretty safe. The "other kinds of exception" would be like, lacking permissions, but that will break other things so it shouldn't be untraceable.